### PR TITLE
Claims migration for Centrifuge

### DIFF
--- a/packages/plugins/crowdloan/src/commands/crowdloan.ts
+++ b/packages/plugins/crowdloan/src/commands/crowdloan.ts
@@ -1046,7 +1046,7 @@ export default class Crowdloan extends CliBaseCommand {
 
             additionals.forEach((contributor) => {
                 check(contributor);
-                this.logger.info("Contributor Extra:" + JSONbig.stringify(contributor))
+                this.logger.debug("Contributor Extra:" + JSONbig.stringify(contributor))
                 let hexAddress;
                 try {
                      hexAddress = `0x${hexEncode(decodeAddress(contributor.address))}`;
@@ -1060,13 +1060,13 @@ export default class Crowdloan extends CliBaseCommand {
 
                     if (oldAmount !== undefined) {
                         contributions.set(hexAddress, oldAmount + contributor.amount);
-                        this.logger.info("Adapting contribution from " + hexAddress + " to: " + BigInt(oldAmount + contributor.amount));
+                        this.logger.debug("Adapting contribution from " + hexAddress + " to: " + BigInt(oldAmount + contributor.amount));
                     } else {
                         this.logger.warn("Could not fetch contribution amount from existing account " + hexAddress);
                     }
                 } else {
                     contributions.set(hexAddress, contributor.amount);
-                    this.logger.info("Setting contribution from " + hexAddress +" manually to: " + contributor.amount);
+                    this.logger.debug("Setting contribution from " + hexAddress +" manually to: " + contributor.amount);
                 }
             })
         } catch (err) {

--- a/packages/plugins/migration/src/migration/common.ts
+++ b/packages/plugins/migration/src/migration/common.ts
@@ -2,7 +2,21 @@ import {xxhashAsHex} from "@polkadot/util-crypto";
 import {StorageKey} from "@polkadot/types";
 
 
-export async function insertOrNewMap(map: Map<string, Array<any>>, key: string, item: any) {
+
+export function getOrInsertMap(map: Map<string, Map<string, Array<any>>>, key: string): Map<string, Array<any>> {
+    if (map.has(key)) {
+        // We have checked that it exists
+        // @ts-ignore
+        return map.get(key)
+    } else {
+        map.set(key, new Map())
+        // We have checked that it exists
+        // @ts-ignore
+        return map.get(key)
+    }
+}
+
+export async function insertOrNewArray(map: Map<string, Array<any>>, key: string, item: any) {
     if (map.has(key)) {
         let itemsArray = map.get(key);
         // @ts-ignore // We check that above

--- a/packages/plugins/migration/src/migration/migrate.ts
+++ b/packages/plugins/migration/src/migration/migrate.ts
@@ -78,8 +78,8 @@ export async function verifyMigration(
                 if(failed.length !== 0) {
                     failedVerification.push(...failed);
                 }
-            } else if (key === xxhashAsHex("Claims", 128) + xxhashAsHex("UpdateAccount", 128).slice(2)){
-                let failed = await verifyClaimsUpdateAccount(oldData, fromApi, newData, toApi);
+            } else if (key === xxhashAsHex("Claims", 128) + xxhashAsHex("UploadAccount", 128).slice(2)){
+                let failed = await verifyClaimsUploadAccount(oldData, fromApi, newData, toApi);
                 if(failed.length !== 0) {
                     failedVerification.push(...failed);
                 }
@@ -118,7 +118,7 @@ async function verifyClaimsClaimedAmounts(
             let account = newApi.createType("AccountId", key.toU8a(true).slice(-32));
             if (newClaimed.toBigInt() !== oldClaimed.toBigInt()) {
                 console.log(
-                    "ERROR Claims.ClaimedAmount: Missmatch for account" + account.toHex() + "\n",
+                    "ERROR Claims.ClaimedAmounts: Missmatch for account" + account.toHex() + "\n",
                     "Old: " + oldClaimed.toBigInt() + " vs. \n",
                     "New: " + newClaimed.toBigInt()
                 )
@@ -173,7 +173,7 @@ async function verifyClaimsRootHashes(
     return failed;
 }
 
-async function verifyClaimsUpdateAccount(
+async function verifyClaimsUploadAccount(
     oldData: Array<[StorageKey, Uint8Array]>,
     oldApi: ApiPromise,
     newData: Array<[StorageKey, Uint8Array]>,
@@ -198,14 +198,14 @@ async function verifyClaimsUpdateAccount(
 
             if (oldAccount.toHex() !== newAccount.toHex()) {
                 console.log(
-                    "ERROR Claims.UpdateAccount: Missmatch \n",
+                    "ERROR Claims.UploadAccount: Missmatch \n",
                     "Old: " + oldAccount.toHex() + " vs. \n",
                     "New: " + newAccount.toHex()
                 )
                 failed.push([key, value]);
             }
         } else {
-            console.log("ERROR CLAIMS_UPDATE_ACCOUNT: New update account not found...");
+            console.log("ERROR Claims.UploadAccount: New update account not found...");
             failed.push([key, value]);
         }
 

--- a/packages/plugins/migration/src/migration/migrate.ts
+++ b/packages/plugins/migration/src/migration/migrate.ts
@@ -522,8 +522,6 @@ export async function migrate(
         }
     }
 
-    return Promise.reject("TESTING");
-
     for (const dispatchable of dispatchables) {
         await dispatcher.sudoDispatch(dispatchable);
     }

--- a/packages/plugins/migration/src/migration/migrate.ts
+++ b/packages/plugins/migration/src/migration/migrate.ts
@@ -458,25 +458,25 @@ export async function prepareMigrate(
     for (let [prefix, keyValues] of Array.from(transformedData)) {
         // Match all prefixes we want to transform
         if (prefix.startsWith(xxhashAsHex("System", 128))) {
-            let migratedPalletStorageItems = await prepareSystem(toApi, keyValues);
-            migrationXts.set(prefix, migratedPalletStorageItems);
+            let palletItems = getOrInsertMap(migrationXts, prefix);
+            await prepareSystem(toApi, palletItems, keyValues);
 
         } else if (prefix.startsWith(xxhashAsHex("Balances", 128))) {
-            let migratedPalletStorageItems = await prepareBalances(toApi, keyValues);
-            migrationXts.set(prefix, migratedPalletStorageItems)
+            let palletItems = getOrInsertMap(migrationXts, prefix);
+            await prepareBalances(toApi, palletItems, keyValues);
 
         } else if (prefix.startsWith(xxhashAsHex("Vesting", 128))) {
-            let migratedPalletStorageItems = await prepareVesting(toApi, keyValues);
-            migrationXts.set(prefix, migratedPalletStorageItems)
+            let palletItems = getOrInsertMap(migrationXts, prefix);
+            await prepareVesting(toApi, palletItems, keyValues);
 
         } else if (prefix.startsWith(xxhashAsHex("Proxy", 128))) {
-            let migratedPalletStorageItems = await prepareProxy(toApi, keyValues);
-            migrationXts.set(prefix, migratedPalletStorageItems)
+            let palletItems = getOrInsertMap(migrationXts, prefix);
+            await prepareProxy(toApi, palletItems, keyValues);
 
         } else if (prefix.startsWith(xxhashAsHex("Claims", 128))) {
             let palletItems = getOrInsertMap(migrationXts, prefix);
             await prepareClaims(toApi, palletItems, keyValues);
-            
+
         }else {
             return Promise.reject("Fetched data that can not be migrated. PatriciaKey is: " + prefix);
         }
@@ -651,10 +651,9 @@ async function prepareClaimsUploadAccount(
 
 async function prepareSystem(
     toApi: ApiPromise,
+    xts: Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>>,
     keyValues: Map<string, Array<StorageItem>>
-):  Promise<Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>>> {
-    let xts: Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>> = new Map();
-
+){
     // Match against the actual storage items of a pallet.
     for(let [palletStorageItemKey, values] of Array.from(keyValues)) {
         if (palletStorageItemKey === (xxhashAsHex("System", 128) + xxhashAsHex("Account", 128).slice(2))) {
@@ -664,16 +663,13 @@ async function prepareSystem(
             return Promise.reject("Fetched data that can not be migrated. PatriciaKey is: " + palletStorageItemKey);
         }
     }
-
-    return xts;
 }
 
 async function prepareProxy(
     toApi: ApiPromise,
+    xts: Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>>,
     keyValues: Map<string, Array<StorageItem>>
-):  Promise<Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>>> {
-    let xts: Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>> = new Map();
-
+) {
     // Match against the actual storage items of a pallet.
     for(let [palletStorageItemKey, values] of Array.from(keyValues)) {
         if (palletStorageItemKey === (xxhashAsHex("Proxy", 128) + xxhashAsHex("Proxies", 128).slice(2))) {
@@ -683,8 +679,6 @@ async function prepareProxy(
             return Promise.reject("Fetched data that can not be migrated. PatriciaKey is: " + palletStorageItemKey);
         }
     }
-
-    return xts;
 }
 
 async function prepareProxyProxies(
@@ -780,10 +774,9 @@ async function retrieveIdAndAccount(item: StorageMapValue): Promise<[ Uint8Array
 
 async function prepareBalances(
     toApi: ApiPromise,
+    xts: Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>>,
     keyValues: Map<string, Array<StorageItem>>
-):  Promise<Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>>> {
-    let xts: Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>> = new Map();
-
+) {
     for(let [palletStorageItemKey, values] of Array.from(keyValues)) {
         if (palletStorageItemKey === xxhashAsHex("Balances", 128) + xxhashAsHex("TotalIssuance", 128).slice(2)) {
             xts.set(palletStorageItemKey, await prepareBalancesTotalIssuance(toApi, values));
@@ -791,8 +784,6 @@ async function prepareBalances(
             return Promise.reject("Fetched data that can not be migrated. PatriciaKey is: " + palletStorageItemKey);
         }
     }
-
-    return xts;
 }
 
 async function prepareBalancesTotalIssuance(
@@ -820,10 +811,9 @@ async function prepareBalancesTotalIssuance(
 
 async function prepareVesting(
     toApi: ApiPromise,
+    xts: Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>>,
     keyValues: Map<string, Array<StorageItem>>
-):  Promise<Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>>> {
-    let xts: Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>> = new Map();
-
+) {
     for(let [palletStorageItemKey, values] of Array.from(keyValues)) {
         if (palletStorageItemKey === xxhashAsHex("Vesting", 128) + xxhashAsHex("Vesting", 128).slice(2)) {
             xts.set(palletStorageItemKey, await prepareVestingVestingInfo(toApi, values));
@@ -832,8 +822,6 @@ async function prepareVesting(
             return Promise.reject("Fetched data that can not be migrated. PatriciaKey is: " + palletStorageItemKey);
         }
     }
-
-    return xts;
 }
 
 async function prepareVestingVestingInfo(


### PR DESCRIPTION
This PR contains the migration of the previously named `RadClaims` pallet (on centrifuge stand-alone) to the newly named `Claims` pallet (on centrifuge parachain). 

The migration is capable of migrating the complete storage, including the account that is allowed to upload new root-hashes. If this is not needed, please omit fetching this storage via the configuration. 

Tasks: 
- [ ] Adapt the verification of the migration to be able to handle changes in naming. 
      E.g. fetch storage from old-chain via `RadClaims`, fetch storage in verification from new-chain via `Claims`