### PR TITLE
feat: Verify migration with renaming

### DIFF
--- a/packages/plugins/migration/README.md
+++ b/packages/plugins/migration/README.md
@@ -71,17 +71,11 @@ itself.
 * --verify : If flag is given, the migration will be verified directly afterwards.
 * --just-verify : This option expects a path to a json file of the following form in order to verify a past migration.
     ```json
-    export interface MigrationStats {
+    export interface MigrationSummary {
       fromFetchedAt: string,
       fromStartedAt: string,
       toStartedAt: string
       toEndAt: string,
-      modules: Array<SequenceConfig>,
-    }
-  
-    export interface SequenceConfig {
-      name: string,
-      item: string,
     }
     ```
   

--- a/packages/plugins/migration/src/commands/migration.ts
+++ b/packages/plugins/migration/src/commands/migration.ts
@@ -315,11 +315,7 @@ export default class Migration extends CliBaseCommand {
         }
     }
 
-    async checkAvailability(elements: Array<StorageElement>): Promise<Array<StorageElement>> {
-        // TODO: Check if migration is possible with elements. In our case it is...
-        return elements;
-    }
-
+    // Transform the `Config modules` into an array of storage elements
     async createStorageElements(): Promise<Array<StorageElement>> {
         const toBeMigrated = this.migrationConfig.modules;
         let storageElements: Array<StorageElement> = new Array();
@@ -332,7 +328,7 @@ export default class Migration extends CliBaseCommand {
             }
         }
 
-        return this.checkAvailability(storageElements);
+        return storageElements;
     }
 
     async createSequenceElements(): Promise<Array<StorageElement>> {

--- a/packages/plugins/migration/src/migration/common.ts
+++ b/packages/plugins/migration/src/migration/common.ts
@@ -49,7 +49,7 @@ export abstract class StorageElement {
     }
 }
 
-export class PalletElement extends StorageElement{
+export class PalletElement extends StorageElement {
     readonly pallet: string
     readonly palletHash: string
 

--- a/packages/plugins/migration/src/migration/interfaces.ts
+++ b/packages/plugins/migration/src/migration/interfaces.ts
@@ -10,42 +10,22 @@ export type Migrations = Array<Migration>;
 // A migration, i.e, a type capturing the migratable item in the source and in the destination chain.
 // For example, { source: (RadClaims, AccountBalances), destination: (Claims, ClaimedAmounts) }.
 export interface Migration {
-    // The migratable info on the source chain
-    source: Migratable,
-    // The migratable info on the destination chain
-    destination: Migratable
+    // The source storage item
+    source: StorageItem,
+    // The destination storage item
+    destination: StorageItem
 }
 
-// Union type capturing a migratable item.
-export type Migratable = Pallet | PalletStorageItem;
-
-export interface Pallet {
-    type: MigratableType.Pallet;
-    name: string;
-}
-
-// A Pallet Storage item, e.g. `{ pallet: "Balances", name: "TotalIssuance" }`
-export interface PalletStorageItem {
-    type: MigratableType.PalletStorageItem;
-    // The pallet this item is under
+// A Pallet Storage item, e.g. `{ pallet: "Balances", item: "TotalIssuance" }`
+export interface StorageItem {
+    // The name of the pallet
     pallet: string;
     // The name of the storage item
-    name: string;
+    item: string;
 }
 
-// The different Migratable variant types
-export enum MigratableType {
-    Pallet = "Pallet",
-    PalletStorageItem = "PalletStorageItem",
-}
-
-export function toStorageElement(m: Migratable): StorageElement {
-    switch (m.type) {
-        case MigratableType.Pallet:
-            return new PalletElement(m.name);
-        case MigratableType.PalletStorageItem:
-            return new StorageItemElement(m.pallet, m.name);
-    }
+export function toStorageElement(x: StorageItem): StorageElement {
+    return new StorageItemElement(x.pallet, x.item)
 }
 
 export interface MigrationSummary {

--- a/packages/plugins/migration/src/migration/interfaces.ts
+++ b/packages/plugins/migration/src/migration/interfaces.ts
@@ -8,8 +8,43 @@ export interface Config {
 }
 
 export interface ModuleConfig {
+    // The pallet name
     name: string,
+    // The pallet's item name if applicable
     item: StorageItemConfig | undefined,
+}
+
+export interface SequenceConfig {
+    name: string,
+    item: string,
+}
+
+// ---------- New stuff
+
+export interface Migration {
+    // The items to be migrated, sorted by the order the migration *must* take place.
+    items: Array<Item>
+}
+
+// A migration item, i.e, a type describing a Migratable from
+// the source chain and its destination.
+export interface Item {
+    source: Migratable,
+    destination: Migratable
+}
+
+// Union type capturing a migratable item.
+export type Migratable = Pallet | PalletStorageItem;
+
+export interface Pallet {
+    name: string
+}
+
+export interface PalletStorageItem {
+    // The pallet this item is under
+    pallet: Pallet,
+    // the name of the storage item
+    name: string
 }
 
 export interface StorageItemConfig {
@@ -21,10 +56,6 @@ export interface MigrationStats {
     fromStartedAt: bigint,
     toStartedAt: bigint
     toEndAt: bigint,
+    //TODO(nuno): consider delete this field or make it `Migration`
     modules: Array<SequenceConfig>,
-}
-
-export interface SequenceConfig {
-    name: string,
-    item: string,
 }

--- a/packages/plugins/migration/src/migration/migrate.ts
+++ b/packages/plugins/migration/src/migration/migrate.ts
@@ -5,69 +5,191 @@ import {StorageItemElement, PalletElement, StorageElement, StorageItem, StorageV
 import {ApiTypes, SubmittableExtrinsic} from "@polkadot/api/types";
 import {KeyringPair} from "@polkadot/keyring/types";
 import {StorageKey} from "@polkadot/types";
-import {fork} from "../migration/fork";
+import {zippedFork} from "../migration/fork";
 import {compactAddLength} from "@polkadot/util"
 import {Dispatcher} from "@centrifuge-cli/dispatcher/dist/dispatcher";
+import {Migrations} from "./interfaces";
+
+interface ChainVerification {
+    api: ApiPromise,
+    startBlock: Hash,
+    endBlock: Hash
+}
 
 export async function verifyMigration(
-    toApi: ApiPromise,
-    fromApi: ApiPromise,
-    storageItems: Array<StorageElement>,
-    startTo: Hash,
-    atTo: Hash,
-    startFrom: Hash,
-    atFrom: Hash
+    migrations: Migrations,
+    source: ChainVerification,
+    destination: ChainVerification,
 ): Promise<Array<[StorageKey,  Uint8Array]>> {
-    const forkDataOld = await fork(fromApi, storageItems, atFrom);
-    const forkDataNew = await fork(toApi, storageItems, atTo);
+    const zipFork = await zippedFork(migrations, source.api, source.endBlock, destination.api, destination.endBlock);
+    const sourceStartBlockNumber = (await source.api.rpc.chain.getBlock(source.startBlock)).block.header.number.toBigInt();
+    const destinationStartBlockNumber = (await destination.api.rpc.chain.getBlock(destination.startBlock)).block.header.number.toBigInt();
+    let failedVerification = [];
 
-    const startToAsNum = (await toApi.rpc.chain.getBlock(startTo)).block.header.number.toBigInt();
-    const startFromAsNum = (await fromApi.rpc.chain.getBlock(startFrom)).block.header.number.toBigInt();
-
-    let failedVerification= new Array();
-
-    // create a good counter
-    let itemsToCheck = 0;
-    for (const [_key, data] of Array.from(forkDataOld)) {
-        itemsToCheck += data.length;
-    }
-    console.log("Starting verification of " + itemsToCheck + " migrated storage keys.");
-
-    process.stdout.write("    Verifying:    0/" + itemsToCheck + "\r");
-    for (const [key, oldData] of Array.from(forkDataOld)) {
-
-        let newData = forkDataNew.get(key);
-        if (newData === undefined){
-            failedVerification.push(...oldData);
-        } else {
-            if (key === xxhashAsHex("System", 128) + xxhashAsHex("Account", 128).slice(2)) {
-                let failed = await verifySystemAccount(oldData, fromApi, newData, toApi);
-                if(failed.length !== 0) {
-                    failedVerification.push(...failed);
-                }
-            } else if (key === xxhashAsHex("Balances", 128) + xxhashAsHex("TotalIssuance", 128).slice(2)){
-                let failed = await verifyBalanceTotalIssuance(oldData, fromApi, newData, toApi, startToAsNum);
-                if(failed.length !== 0) {
-                    failedVerification.push(...failed);
-                }
-            } else if (key === xxhashAsHex("Vesting", 128) + xxhashAsHex("Vesting", 128).slice(2)){
-                let failed = await verifyVestingVesting(oldData, fromApi, newData, toApi, startFromAsNum, startToAsNum);
-                if(failed.length !== 0) {
-                    failedVerification.push(...failed);
-                }
-            } else if (key === xxhashAsHex("Proxy", 128) + xxhashAsHex("Proxies", 128).slice(2)){
-                let failed = await verifyProxyProxies(oldData, fromApi, newData, toApi);
-                if(failed.length !== 0) {
-                    failedVerification.push(...failed);
-                }
-            } else {
-                failedVerification.push(...oldData);
-                console.log("Some data from old could not be verified here...");
+    for (const [ [_sourceKey, sourceData], [destKey, destData]] of zipFork) {
+        if (destKey === xxhashAsHex("System", 128) + xxhashAsHex("Account", 128).slice(2)) {
+            let failed = await verifySystemAccount(sourceData, source.api, destData, destination.api);
+            if (failed.length > 0) {
+                failedVerification.push(...failed);
             }
+        } else if (destKey === xxhashAsHex("Balances", 128) + xxhashAsHex("TotalIssuance", 128).slice(2)) {
+            let failed = await verifyBalanceTotalIssuance(sourceData, source.api, destData, destination.api, destinationStartBlockNumber);
+            if (failed.length !== 0) {
+                failedVerification.push(...failed);
+            }
+        } else if (destKey === xxhashAsHex("Vesting", 128) + xxhashAsHex("Vesting", 128).slice(2)) {
+            let failed = await verifyVestingVesting(sourceData, source.api, destData, destination.api, sourceStartBlockNumber, destinationStartBlockNumber);
+            if (failed.length > 0) {
+                failedVerification.push(...failed);
+            }
+        } else if (destKey === xxhashAsHex("Proxy", 128) + xxhashAsHex("Proxies", 128).slice(2)) {
+            let failed = await verifyProxyProxies(sourceData, source.api, destData, destination.api);
+            if (failed.length > 0) {
+                failedVerification.push(...failed);
+            }
+        } else if (destKey === xxhashAsHex("Claims", 128) + xxhashAsHex("ClaimedAmounts", 128).slice(2)){
+            let failed = await verifyClaimsClaimedAmounts(sourceData, source.api, destData, destination.api);
+            if(failed.length !== 0) {
+                failedVerification.push(...failed);
+            }
+        } else if (destKey === xxhashAsHex("Claims", 128) + xxhashAsHex("RootHashes", 128).slice(2)){
+            let failed = await verifyClaimsRootHashes(sourceData, source.api, destData, destination.api);
+            if(failed.length !== 0) {
+                failedVerification.push(...failed);
+            }
+        } else if (destKey === xxhashAsHex("Claims", 128) + xxhashAsHex("UploadAccount", 128).slice(2)){
+            let failed = await verifyClaimsUploadAccount(sourceData, source.api, destData, destination.api);
+            if(failed.length !== 0) {
+                failedVerification.push(...failed);
+            }
+        } else {
+            failedVerification.push(...sourceData);
+            console.log("Expected to verify data that we are not prepared to handle");
         }
     }
 
     return failedVerification;
+}
+
+async function verifyClaimsClaimedAmounts(
+    oldData: Array<[StorageKey, Uint8Array]>,
+    oldApi: ApiPromise,
+    newData: Array<[StorageKey, Uint8Array]>,
+    newApi: ApiPromise
+): Promise<Array<[StorageKey, Uint8Array]>> {
+    let failed = new Array();
+    let newDataMap = newData.reduce(function (map, [key, data]) {
+        let accountId = newApi.createType("AccountId", key.toU8a(true).slice(-32));
+        map.set(accountId.toHex(), data);
+        return map;
+    }, new Map<string, Uint8Array>());
+
+    let checked = 0;
+    for(let [sourceKey, sourceClaimedAmount] of oldData) {
+        process.stdout.write("    Verifying:    "+ checked +"/ \r");
+        let account = newApi.createType("AccountId", sourceKey.toU8a(true).slice(-32)).toHex();
+        let destClaimedAmount = newDataMap.get(account);
+
+        if (destClaimedAmount !== undefined) {
+            let sourceClaimedBalance = oldApi.createType('Balance', sourceClaimedAmount);
+            let destClaimedBalance = newApi.createType('Balance', destClaimedAmount);
+
+            if (destClaimedBalance.toBigInt() !== sourceClaimedBalance.toBigInt()) {
+                console.log(
+                    "ERROR Claims.ClaimedAmounts: Mismatch for account" + account + "\n",
+                    "Amount in source: " + sourceClaimedBalance.toBigInt() + "\n",
+                    "Amount in destination: " + destClaimedBalance.toBigInt()
+                )
+                failed.push([sourceKey, sourceClaimedAmount]);
+            }
+        } else {
+            console.log("ERROR Claims.ClaimedAmounts: New claimed amount for account " + sourceKey.toHex() + " not found in the destination chain...");
+            failed.push([sourceKey, sourceClaimedAmount]);
+        }
+        checked += 1;
+    }
+
+    return failed;
+}
+
+async function verifyClaimsRootHashes(
+    oldData: Array<[StorageKey, Uint8Array]>,
+    oldApi: ApiPromise,
+    newData: Array<[StorageKey, Uint8Array]>,
+    newApi: ApiPromise
+): Promise<Array<[StorageKey, Uint8Array]>> {
+    let failed = new Array();
+
+    let newDataMap = newData.reduce(function (map, obj) {
+        map.set(obj[0].toHex(), obj[1]);
+        return map;
+    }, new Map<string, Uint8Array>());
+
+    let checked = 0;
+    for(let [key, value] of oldData) {
+        process.stdout.write("    Verifying:    "+ checked +"/ \r");
+
+        let newScale = newDataMap.get(key.toHex());
+        if (newScale !== undefined) {
+            if (newScale !== value) {
+                console.log(
+                    "ERROR Claims.RootHashes: Missmatch in boolean \n",
+                    "Old: " + newScale + " vs. \n",
+                    "New: " + value
+                )
+                failed.push([key, value]);
+            }
+        } else {
+            console.log("ERROR Claims.RootHashes: New root hash for old key of " + key.toHex() +" not found...");
+            failed.push([key, value]);
+        }
+
+        checked += 1;
+    }
+
+    return failed;
+}
+
+async function verifyClaimsUploadAccount(
+    oldData: Array<[StorageKey, Uint8Array]>,
+    oldApi: ApiPromise,
+    newData: Array<[StorageKey, Uint8Array]>,
+    newApi: ApiPromise
+): Promise<Array<[StorageKey, Uint8Array]>> {
+    let failed = new Array();
+
+    let newDataMap = newData.reduce(function (map, obj) {
+        map.set(obj[0].toHex(), obj[1]);
+        return map;
+    }, new Map<string, Uint8Array>());
+
+    let checked = 0;
+    for(let [key, value] of oldData) {
+        process.stdout.write("    Verifying:    "+ checked +"/ \r");
+
+        let oldAccount = oldApi.createType('AccountId', value);
+
+        let newScale = newDataMap.get(key.toHex());
+        if (newScale !== undefined) {
+            let newAccount = newApi.createType('AccountId', newScale);
+
+            if (oldAccount.toHex() !== newAccount.toHex()) {
+                console.log(
+                    "ERROR Claims.UploadAccount: Missmatch \n",
+                    "Old: " + oldAccount.toHex() + " vs. \n",
+                    "New: " + newAccount.toHex()
+                )
+                failed.push([key, value]);
+            }
+        } else {
+            console.log("ERROR Claims.UploadAccount: New update account not found...");
+            failed.push([key, value]);
+        }
+
+        checked += 1;
+    }
+
+    return failed;
 }
 
 async function verifySystemAccount(
@@ -302,73 +424,72 @@ async function verifyVestingVesting(
 }
 
 
-export async function prepareMigrate(
-    transformedData: Map<string, Map<string, Array<StorageItem>>>,
+// Build the extrinsics that will have the data inserted in the destination chain.
+export async function buildExtrinsics(
+    // The data in the schema accepted by the destination chain
+    destData: Map<string, Map<string, Array<StorageItem>>>,
     fromApi: ApiPromise,
     toApi: ApiPromise,
 ): Promise<Map<string, Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>>>> {
-    let migrationXts: Map<string, Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>>> = new Map();
+    let extrinsics: Map<string, Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>>> = new Map();
 
     // For every prefix do the correct transformation.
-    for (let [prefix, keyValues] of Array.from(transformedData)) {
+    for (let [prefix, keyValues] of Array.from(destData)) {
         // Match all prefixes we want to transform
         if (prefix.startsWith(xxhashAsHex("System", 128))) {
             let migratedPalletStorageItems = await prepareSystem(toApi, keyValues);
-            migrationXts.set(prefix, migratedPalletStorageItems)
+            extrinsics.set(prefix, migratedPalletStorageItems)
 
         } else if (prefix.startsWith(xxhashAsHex("Balances", 128))) {
             let migratedPalletStorageItems = await prepareBalances(toApi, keyValues);
-            migrationXts.set(prefix, migratedPalletStorageItems)
+            extrinsics.set(prefix, migratedPalletStorageItems)
 
         } else if (prefix.startsWith(xxhashAsHex("Vesting", 128))) {
             let migratedPalletStorageItems = await prepareVesting(toApi, keyValues);
-            migrationXts.set(prefix, migratedPalletStorageItems)
+            extrinsics.set(prefix, migratedPalletStorageItems)
 
         } else if (prefix.startsWith(xxhashAsHex("Proxy", 128))) {
             let migratedPalletStorageItems = await prepareProxy(toApi, keyValues);
-            migrationXts.set(prefix, migratedPalletStorageItems)
+            extrinsics.set(prefix, migratedPalletStorageItems)
 
         } else {
             return Promise.reject("Fetched data that can not be migrated. PatriciaKey is: " + prefix);
         }
     }
 
-    return migrationXts;
+    return extrinsics;
 }
 
+// Run the migration by applying the given `extrinsics` in the order defined by `elements`.
 export async function migrate(
+    extrinsics: Map<string, Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>>>,
+    elements: Array<StorageElement>,
     toApi: ApiPromise,
-    executor: KeyringPair,
-    sequence: Array<StorageElement>,
-    data: Map<string, Map<string, Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>>>,
+    keyPair: KeyringPair,
     cbErr: (failed: Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>) => void
 ) : Promise<Array<[Hash, bigint]>>
 {
-    const { nonce } = await toApi.query.system.account(executor.address);
-
-    let dispatcher = new Dispatcher(toApi, executor, nonce.toBigInt(), cbErr, 5, 50);
-
+    const { nonce } = await toApi.query.system.account(keyPair.address);
+    let dispatcher = new Dispatcher(toApi, keyPair, nonce.toBigInt(), cbErr, 5, 50);
     let dispatchables: Array<Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>> = new Array();
 
-    for (const one of sequence) {
-        if (one instanceof PalletElement) {
-            let palletData = data.get(one.palletHash);
-            if (palletData !== undefined) {
-                for(const [key, data] of Array.from(palletData)) {
-                    dispatchables.push(data);
-                }
-            } else {
-                return Promise.reject("Sequence element was NOT part of transformation. Pallet: " + one.pallet);
+    for (const element of elements) {
+        if (element instanceof PalletElement) {
+            let palletData = extrinsics.get(element.palletHash);
+            if (palletData === undefined) {
+                return Promise.reject("Sequence element was NOT part of transformation. Pallet: " + element.pallet);
             }
 
-        } else if (one instanceof StorageItemElement) {
-            let storageItemData = data.get(one.palletHash)?.get(one.key)
-
-            if (storageItemData !== undefined) {
-                dispatchables.push(storageItemData);
-            } else {
-                return Promise.reject("Sequence element was NOT part of transformation. Pallet: " + one.pallet + ", Item: " + one.item);
+            for (const [_key, data] of Array.from(palletData)) {
+                dispatchables.push(data);
             }
+        } else if (element instanceof StorageItemElement) {
+            let storageItemData = extrinsics.get(element.palletHash)?.get(element.key)
+            if (storageItemData === undefined) {
+                return Promise.reject("Sequence element was NOT part of transformation. Pallet: " + element.pallet + ", Item: " + element.item);
+            }
+
+            dispatchables.push(storageItemData);
         } else {
             return Promise.reject("Unreachable Code. qed.");
         }
@@ -425,12 +546,9 @@ async function prepareProxyProxies(
     values: StorageItem[]
 ): Promise<Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>>> {
     let xts: Array<SubmittableExtrinsic<ApiTypes, SubmittableResult>> = new Array();
-
     let packetOfProxies: Array<[AccountId, Balance,  Uint8Array]> = new Array();
-
     // @ts-ignore
     const maxProxiesOnChain = toApi.consts.migration.migrationMaxProxies.toNumber();
-
     // For safety reasons we reduce 1/3 of the max amount here
     const maxProxies = Math.round(maxProxiesOnChain - ((1/3) * maxProxiesOnChain));
 

--- a/packages/plugins/migration/src/migration/migrate.ts
+++ b/packages/plugins/migration/src/migration/migrate.ts
@@ -52,11 +52,6 @@ export async function verifyMigration(
             if(failed.length !== 0) {
                 failedVerification.push(...failed);
             }
-        } else if (destKey === xxhashAsHex("Claims", 128) + xxhashAsHex("RootHashes", 128).slice(2)){
-            let failed = await verifyClaimsRootHashes(sourceData, source.api, destData, destination.api);
-            if(failed.length !== 0) {
-                failedVerification.push(...failed);
-            }
         } else if (destKey === xxhashAsHex("Claims", 128) + xxhashAsHex("UploadAccount", 128).slice(2)){
             let failed = await verifyClaimsUploadAccount(sourceData, source.api, destData, destination.api);
             if(failed.length !== 0) {
@@ -106,44 +101,6 @@ async function verifyClaimsClaimedAmounts(
             console.log("ERROR Claims.ClaimedAmounts: New claimed amount for account " + sourceKey.toHex() + " not found in the destination chain...");
             failed.push([sourceKey, sourceClaimedAmount]);
         }
-        checked += 1;
-    }
-
-    return failed;
-}
-
-async function verifyClaimsRootHashes(
-    oldData: Array<[StorageKey, Uint8Array]>,
-    oldApi: ApiPromise,
-    newData: Array<[StorageKey, Uint8Array]>,
-    newApi: ApiPromise
-): Promise<Array<[StorageKey, Uint8Array]>> {
-    let failed = new Array();
-
-    let newDataMap = newData.reduce(function (map, obj) {
-        map.set(obj[0].toHex(), obj[1]);
-        return map;
-    }, new Map<string, Uint8Array>());
-
-    let checked = 0;
-    for(let [key, value] of oldData) {
-        process.stdout.write("    Verifying:    "+ checked +"/ \r");
-
-        let newScale = newDataMap.get(key.toHex());
-        if (newScale !== undefined) {
-            if (newScale !== value) {
-                console.log(
-                    "ERROR Claims.RootHashes: Missmatch in boolean \n",
-                    "Old: " + newScale + " vs. \n",
-                    "New: " + value
-                )
-                failed.push([key, value]);
-            }
-        } else {
-            console.log("ERROR Claims.RootHashes: New root hash for old key of " + key.toHex() +" not found...");
-            failed.push([key, value]);
-        }
-
         checked += 1;
     }
 

--- a/packages/plugins/migration/src/migration/transform.ts
+++ b/packages/plugins/migration/src/migration/transform.ts
@@ -5,6 +5,7 @@ import { insertOrNewMap, StorageItem, StorageValueValue, StorageMapValue } from 
 import {StorageKey} from "@polkadot/types";
 import {compactAddLength} from "@polkadot/util";
 
+// Transform the source state to match the appropriate schema in the destination
 export async function transform(
     forkData: Map<string, Array<[ StorageKey, Uint8Array]>>,
     fromApi: ApiPromise,


### PR DESCRIPTION
We add support to verify migrations that involve renaming of the migrated items, for example, `RadClaims.AccountBalances` -> `Claims.ClaimedAmounts`. For that, we now expect the config file with all the migrations to be performed to specify the `source` and the `destination` migratable item.

We also clean up the config so that there is no longer a need for both a general "ModuleConfig" and a "SequenceConfig"; the new `Migrations` type offers both the info about the items to migrate and implicitly the order in which the migrations must take place.

Finally, we improve some naming, structure, and grouping of code.

### New config example

```json
[
  {
    "source": {
      "pallet": "RadClaims",
      "item": "AccountBalances"
    },
    "destination": {
      "pallet": "Claims",
      "item": "ClaimedAmounts"
    }
  },
  {
    "source": {
      "pallet": "RadClaims",
      "item": "UploadAccount"
    },
    "destination": {
      "pallet": "Claims",
      "item": "UploadAccount"
    }
  }
]
```