### PR TITLE
feature: Tinlake rewards claims migration 

### DIFF
--- a/packages/plugins/crowdloan/src/commands/crowdloan.ts
+++ b/packages/plugins/crowdloan/src/commands/crowdloan.ts
@@ -1046,7 +1046,7 @@ export default class Crowdloan extends CliBaseCommand {
 
             additionals.forEach((contributor) => {
                 check(contributor);
-                this.logger.info("Contributor Extra:" + JSONbig.stringify(contributor))
+                this.logger.debug("Contributor Extra:" + JSONbig.stringify(contributor))
                 let hexAddress;
                 try {
                      hexAddress = `0x${hexEncode(decodeAddress(contributor.address))}`;
@@ -1060,13 +1060,13 @@ export default class Crowdloan extends CliBaseCommand {
 
                     if (oldAmount !== undefined) {
                         contributions.set(hexAddress, oldAmount + contributor.amount);
-                        this.logger.info("Adapting contribution from " + hexAddress + " to: " + BigInt(oldAmount + contributor.amount));
+                        this.logger.debug("Adapting contribution from " + hexAddress + " to: " + BigInt(oldAmount + contributor.amount));
                     } else {
                         this.logger.warn("Could not fetch contribution amount from existing account " + hexAddress);
                     }
                 } else {
                     contributions.set(hexAddress, contributor.amount);
-                    this.logger.info("Setting contribution from " + hexAddress +" manually to: " + contributor.amount);
+                    this.logger.debug("Setting contribution from " + hexAddress +" manually to: " + contributor.amount);
                 }
             })
         } catch (err) {

--- a/packages/plugins/migration/src/commands/migration.ts
+++ b/packages/plugins/migration/src/commands/migration.ts
@@ -16,7 +16,8 @@ import {buildExtrinsics, migrate, verifyMigration} from "../migration/migrate";
 import {
     Credentials,
     Migrations,
-    MigrationSummary, toStorageElement
+    MigrationSummary,
+    toStorageElement
 } from "../migration/interfaces";
 
 const JSONbig = require('json-bigint')({ useNativeBigInt: true, alwaysParseAsBig: true });

--- a/packages/plugins/migration/src/migration/common.ts
+++ b/packages/plugins/migration/src/migration/common.ts
@@ -2,7 +2,21 @@ import {xxhashAsHex} from "@polkadot/util-crypto";
 import {StorageKey} from "@polkadot/types";
 
 
-export async function insertOrNewMap(map: Map<string, Array<any>>, key: string, item: any) {
+
+export function getOrInsertMap(map: Map<string, Map<string, Array<any>>>, key: string): Map<string, Array<any>> {
+    if (map.has(key)) {
+        // We have checked that it exists
+        // @ts-ignore
+        return map.get(key)
+    } else {
+        map.set(key, new Map())
+        // We have checked that it exists
+        // @ts-ignore
+        return map.get(key)
+    }
+}
+
+export async function insertOrNewArray(map: Map<string, Array<any>>, key: string, item: any) {
     if (map.has(key)) {
         let itemsArray = map.get(key);
         // @ts-ignore // We check that above

--- a/packages/plugins/migration/src/migration/transform.ts
+++ b/packages/plugins/migration/src/migration/transform.ts
@@ -57,11 +57,6 @@ async function transformClaims (fromApi: ApiPromise, toApi: ApiPromise, state: M
         if (patriciaKey.toHex().startsWith(xxhashAsHex("RadClaims", 128) + xxhashAsHex("AccountBalances", 128).slice(2))) {
             let pkStorageItem = xxhashAsHex("Claims", 128) + xxhashAsHex("ClaimedAmounts", 128).slice(2);
             await insertOrNewArray(state, pkStorageItem, await transformClaimsClaimedAmounts(fromApi, toApi, patriciaKey, value));
-
-        } else if (patriciaKey.toHex().startsWith(xxhashAsHex("RadClaims", 128) + xxhashAsHex("RootHashes", 128).slice(2))) {
-            let pkStorageItem = xxhashAsHex("Claims", 128) + xxhashAsHex("RootHashes", 128).slice(2);
-            await insertOrNewArray(state, pkStorageItem, await transformClaimsRootHashes(fromApi, toApi, patriciaKey, value));
-
         } else if (patriciaKey.toHex().startsWith(xxhashAsHex("RadClaims", 128) + xxhashAsHex("UploadAccount", 128).slice(2))) {
             let pkStorageItem = xxhashAsHex("Claims", 128) + xxhashAsHex("UploadAccount", 128).slice(2);
             await insertOrNewArray(state, pkStorageItem, await transformClaimsUploadAccount(fromApi, toApi, patriciaKey, value));
@@ -79,16 +74,6 @@ async function transformClaimsClaimedAmounts(fromApi: ApiPromise, toApi: ApiProm
     let keyWithoutPrefix = completeKey.toHex().slice(66);
     let newKey = toApi.createType("StorageKey", newPrefix + keyWithoutPrefix);
     return new StorageMapValue(scaleClaimedAmountsUser, newKey);
-
-}
-
-async function transformClaimsRootHashes(fromApi: ApiPromise, toApi: ApiPromise, completeKey: StorageKey, scaleRootHashBool:  Uint8Array): Promise<StorageItem> {
-    // We need to update the pallet and the item hash prefixes of the key here
-    let newPrefix = xxhashAsHex("Claims", 128) + xxhashAsHex("RootHashes", 128).slice(2);
-    // First 64 characters plus 0x from hex representation
-    let keyWithoutPrefix = completeKey.toHex().slice(66);
-    let newKey = toApi.createType("StorageKey", newPrefix + keyWithoutPrefix);
-    return new StorageMapValue(scaleRootHashBool, newKey);
 
 }
 


### PR DESCRIPTION
Fork of https://github.com/centrifuge/centrifuge-cli/pull/21
Based off #24 


- We add support to migrate the standalone chain `RadClaims.UploadAccount` and `RadClaims.AccountBalances` to the  parachain `Claims.UploadAccount` and `Claims.ClaimedAmounts`, respectively.

- From #24 make both of the above items verifications handle the renaming and we drop the migration of `RootHashes`. 
